### PR TITLE
Installation instructions with claude-plugins to simplify the two-step process into a single command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Community-driven marketplace for Claude Code commands and plugins.
 
 ## 🚀 Quick Start
 
+### Standard Installation
 Add this marketplace to Claude Code:
 
 ```bash
@@ -25,6 +26,13 @@ Install a specific agent:
 ```bash
 /plugin install accessibility-expert@claude-code-marketplace
 ```
+### One-Command Installation
+Use the [Claude Plugins CLI](https://claude-plugins.dev) to skip the marketplace setup:
+```bash
+npx claude-plugins install @ananddtyagi/claude-code-marketplace/accessibility-expert
+```
+
+This automatically adds the marketplace and installs the specific agent/command in a single step.
 
 ## 🌟 Featured Commands
 


### PR DESCRIPTION
## Changes
- Added "One-Command Installation" section to Quick Start
- Preserves existing installation instructions as the primary method
- Links to Claude Plugins CLI documentation

## Rationale

The standard Claude Code workflow requires users to:
1. Add marketplace: `/plugin marketplace add ananddtyagi/claude-code-marketplace`
2. Install plugin: `/plugin install <plugin-name>`

This CLI tool automates both steps:
```bash
npx claude-plugins install @ananddtyagi/claude-code-marketplace/<plugin-name>
```

Benefits:
- Reduces friction for first-time users
- Simplifies one-off installations
- Cleaner for documentation examples

## Notes
- CLI is open-source and maintained at https://github.com/Kamalnrf/claude-plugins
- No changes to plugin functionality or dependencies