### PR TITLE
  Fix Claude Code reserved name error by renaming marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "ananddtyagi-marketplace",
+  "name": "claude-code-commands",
   "owner": {
     "name": "Claude Code Commands Community",
     "email": "hello@claudecodecommands.com"


### PR DESCRIPTION
  ## Problem

  Users cannot add this marketplace because `"claude-code-marketplace"` is now a reserved name:

  /plugin marketplace add ananddtyagi/claude-code-marketplace
  Error: The name 'claude-code-marketplace' is reserved for official Anthropic marketplaces.

  Currently, users must fork this repo and manually change the `"name"` field themselves before they can use the marketplace. This is a significant barrier to adoption.

  ## Proposed Solution

  Change the `"name"` field in `.claude-plugin/marketplace.json` from `"claude-code-marketplace"` to `"claude-code-commands"`.

  I noticed the README was recently renamed from "Claude Code Commands Marketplace" to "Claude Code Marketplace", but the JSON `"name"` field wasn't updated to match the new branding. Either updating to
  `"claude-code-commands"` or using something else (`"ccc-marketplace"`) or even the owner name  would fix the issue.

  For reference, [GLINCKER/claude-code-marketplace](https://github.com/GLINCKER/claude-code-marketplace) solved this same issue by using `"glincker-marketplace"`. Feel free to change to whatever you deem
  appropriate.

  This is a one-line change that fixes installation for all users.