### PR TITLE
fix marketplace name in order to handle naming conflict due to anthropic update

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-code-marketplace",
+  "name": "cc-marketplace",
   "owner": {
     "name": "Claude Code Commands Community",
     "email": "hello@claudecodecommands.com"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Community-driven marketplace for Claude Code commands and plugins.
 Add this marketplace to Claude Code:
 
 ```bash
-/plugin marketplace add ananddtyagi/claude-code-marketplace
+/plugin marketplace add ananddtyagi/cc-marketplace
 ```
 
 Then browse and install individual plugins (commands or agents):
@@ -18,12 +18,12 @@ Then browse and install individual plugins (commands or agents):
 
 Install a specific command:
 ```bash
-/plugin install lyra@claude-code-marketplace
+/plugin install lyra@cc-marketplace
 ```
 
 Install a specific agent:
 ```bash
-/plugin install accessibility-expert@claude-code-marketplace
+/plugin install accessibility-expert@cc-marketplace
 ```
 
 ## 🌟 Featured Commands

--- a/plugins/experienced-engineer/README.md
+++ b/plugins/experienced-engineer/README.md
@@ -46,20 +46,20 @@ Automatically update your `CLAUDE.md` file to reflect major changes in the codeb
 
 ```bash
 # Add the marketplace (if not already added)
-/plugin marketplace add claude-code-marketplace
+/plugin marketplace add cc-marketplace
 
 # Install the plugin
-/plugin install experienced-engineer@claude-code-marketplace
+/plugin install experienced-engineer@cc-marketplace
 ```
 
 ### Local Development
 
 ```bash
 # Add local marketplace
-/plugin marketplace add /path/to/claude-code-marketplace
+/plugin marketplace add /path/to/cc-marketplace
 
 # Install plugin
-/plugin install experienced-engineer@claude-code-marketplace
+/plugin install experienced-engineer@cc-marketplace
 ```
 
 ## Usage

--- a/plugins/math/README.md
+++ b/plugins/math/README.md
@@ -59,11 +59,11 @@ pip install sympy
 First add this marketplace to Claude Code:
 
 ```bash
-/plugin marketplace add ananddtyagi/claude-code-marketplace
+/plugin marketplace add ananddtyagi/cc-marketplace
 ```
 
 ```bash
-/plugin install math@claude-code-marketplace
+/plugin install math@cc-marketplace
 ```
 
 ### Manual Skill Install (without plugin)


### PR DESCRIPTION
The name of this marketplace has updated from claude-code-marketplace to cc-marketplace .
This should fix any naming issues you face when adding this marketplace!

Credit to @[noahbutcher97](https://github.com/noahbutcher97) for submitting and initial a fix to this https://github.com/ananddtyagi/claude-code-marketplace/pull/19