### PR TITLE
feat: Add SkillForge plugin

### DIFF
--- a/plugins/skillforge/.claude-plugin/plugin.json
+++ b/plugins/skillforge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skillforge",
-  "version": "4.6.3",
-  "description": "Complete AI development toolkit with 78 skills, 20 agents, 12 commands, and 92 hooks. Progressive loading, LangGraph workflows, security patterns, and production-ready development patterns.",
+  "version": "4.6.5",
+  "description": "Complete AI development toolkit with 78 skills, 20 agents, 12 commands, and 90 hooks. Progressive loading, LangGraph workflows, security patterns, and production-ready development patterns.",
   "author": {
     "name": "Yonatan Gross",
     "url": "https://github.com/yonatangross"

--- a/plugins/skillforge/.claude-plugin/plugin.json
+++ b/plugins/skillforge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skillforge",
-  "version": "1.0.0",
-  "description": "Complete AI development toolkit with 33 skills, 12 agents, 10 commands, and 27 hooks. Progressive loading, LangGraph workflows, security patterns, and production-ready development patterns.",
+  "version": "4.6.3",
+  "description": "Complete AI development toolkit with 78 skills, 20 agents, 12 commands, and 92 hooks. Progressive loading, LangGraph workflows, security patterns, and production-ready development patterns.",
   "author": {
     "name": "Yonatan Gross",
     "url": "https://github.com/yonatangross"

--- a/plugins/skillforge/.claude-plugin/plugin.json
+++ b/plugins/skillforge/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "skillforge",
+  "version": "1.0.0",
+  "description": "Complete AI development toolkit with 33 skills, 12 agents, 10 commands, and 27 hooks. Progressive loading, LangGraph workflows, security patterns, and production-ready development patterns.",
+  "author": {
+    "name": "Yonatan Gross",
+    "url": "https://github.com/yonatangross"
+  },
+  "homepage": "https://github.com/yonatangross/skillforge-claude-plugin",
+  "repository": "https://github.com/yonatangross/skillforge-claude-plugin",
+  "license": "MIT",
+  "keywords": [
+    "ai-development",
+    "langgraph",
+    "fastapi",
+    "react",
+    "typescript",
+    "python",
+    "multi-agent",
+    "rag",
+    "semantic-search",
+    "security",
+    "testing",
+    "architecture",
+    "full-stack",
+    "production-ready"
+  ]
+}

--- a/plugins/skillforge/README.md
+++ b/plugins/skillforge/README.md
@@ -1,0 +1,87 @@
+# SkillForge
+
+Complete AI development toolkit for Claude Code with 33 skills, 12 agents, 10 commands, and 27 hooks.
+
+## Installation
+
+```bash
+/plugin install skillforge@cc-marketplace
+```
+
+Or install directly from GitHub:
+
+```bash
+git clone https://github.com/yonatangross/skillforge-claude-plugin .claude
+```
+
+## Features
+
+### Skills (33)
+
+| Category | Skills |
+|----------|--------|
+| **AI/LLM** | ai-native-development, langgraph-workflows, llm-caching-patterns, llm-safety-patterns, langfuse-observability, pgvector-search |
+| **Backend** | api-design-framework, database-schema-designer, streaming-api-patterns, resilience-patterns |
+| **Frontend** | react-server-components-framework, design-system-starter, type-safety-validation, performance-optimization |
+| **Security** | security-checklist, defense-in-depth |
+| **Testing** | testing-strategy-builder, webapp-testing, evidence-verification |
+| **Architecture** | architecture-decision-record, system-design-interrogation, brainstorming |
+| **DevOps** | devops-deployment, observability-monitoring, edge-computing-patterns |
+| **Data** | golden-dataset-management, golden-dataset-curation, golden-dataset-validation |
+
+### Agents (12)
+
+- `backend-system-architect` - API design, database schemas, microservices
+- `frontend-ui-developer` - React 19, TypeScript, accessibility
+- `database-engineer` - PostgreSQL, pgvector, migrations
+- `llm-integrator` - LLM APIs, prompt engineering, streaming
+- `workflow-architect` - LangGraph, multi-agent systems
+- `security-auditor` - OWASP, vulnerability scanning
+- `code-quality-reviewer` - Code review, linting, type checking
+- `test-generator` - Unit/integration/E2E tests
+- `debug-investigator` - Root cause analysis
+- `data-pipeline-engineer` - Embeddings, ETL, vector indexing
+- `rapid-ui-designer` - UI/UX, wireframing, prototyping
+- `ux-researcher` - User research, personas, journey mapping
+
+### Commands (10)
+
+| Command | Description |
+|---------|-------------|
+| `/implement` | Full-power feature implementation with parallel subagents |
+| `/explore` | Deep codebase exploration |
+| `/verify` | Comprehensive feature verification |
+| `/commit` | Smart commit with validation |
+| `/create-pr` | Create PR with auto-generated description |
+| `/review-pr` | Comprehensive PR review |
+| `/fix-issue` | Fix GitHub issue with parallel analysis |
+| `/run-tests` | Comprehensive test execution |
+| `/add-golden` | Add documents to golden dataset |
+| `/brainstorm` | Multi-perspective idea exploration |
+
+### Hooks (27)
+
+Security-hardened hooks for:
+- Lifecycle events (session start/end)
+- Pre-tool validation (file guards, git protection)
+- Post-tool auditing (metrics, error tracking)
+- Notifications (desktop, sound)
+
+## Key Features
+
+- **Progressive Loading**: Token-efficient skill loading via capabilities.json
+- **LangGraph 1.0**: Multi-agent workflows with checkpointing
+- **Security-First**: OWASP Top 10, defense-in-depth, LLM safety
+- **Production-Ready**: Patterns for FastAPI, React 19, PostgreSQL/pgvector
+
+## Repository
+
+https://github.com/yonatangross/skillforge-claude-plugin
+
+## Author
+
+[Yonatan Gross](https://github.com/yonatangross)
+
+## License
+
+MIT

--- a/plugins/skillforge/README.md
+++ b/plugins/skillforge/README.md
@@ -1,6 +1,6 @@
 # SkillForge
 
-Complete AI development toolkit for Claude Code with 78 skills, 20 agents, 12 commands, and 92 hooks.
+Complete AI development toolkit for Claude Code with 78 skills, 20 agents, 12 commands, and 90 hooks.
 
 ## Installation
 

--- a/plugins/skillforge/README.md
+++ b/plugins/skillforge/README.md
@@ -1,6 +1,6 @@
 # SkillForge
 
-Complete AI development toolkit for Claude Code with 33 skills, 12 agents, 10 commands, and 27 hooks.
+Complete AI development toolkit for Claude Code with 78 skills, 20 agents, 12 commands, and 92 hooks.
 
 ## Installation
 
@@ -16,21 +16,30 @@ git clone https://github.com/yonatangross/skillforge-claude-plugin .claude
 
 ## Features
 
-### Skills (33)
+### Skills (78)
 
 | Category | Skills |
 |----------|--------|
-| **AI/LLM** | ai-native-development, langgraph-workflows, llm-caching-patterns, llm-safety-patterns, langfuse-observability, pgvector-search |
-| **Backend** | api-design-framework, database-schema-designer, streaming-api-patterns, resilience-patterns |
-| **Frontend** | react-server-components-framework, design-system-starter, type-safety-validation, performance-optimization |
-| **Security** | security-checklist, defense-in-depth |
-| **Testing** | testing-strategy-builder, webapp-testing, evidence-verification |
-| **Architecture** | architecture-decision-record, system-design-interrogation, brainstorming |
-| **DevOps** | devops-deployment, observability-monitoring, edge-computing-patterns |
-| **Data** | golden-dataset-management, golden-dataset-curation, golden-dataset-validation |
+| **AI/LLM** | agent-loops, embeddings, function-calling, llm-streaming, llm-evaluation, rag-retrieval, reranking-patterns, prompt-caching, ollama-local |
+| **Backend** | api-design-framework, clean-architecture, caching-strategies, rate-limiting, background-jobs, api-versioning, fastapi-advanced |
+| **Frontend** | react-server-components-framework, design-system-starter, type-safety-validation, motion-animation-patterns, performance-optimization |
+| **Security** | owasp-top-10, auth-patterns, input-validation, llm-safety-patterns, security-scanning |
+| **Testing** | unit-testing, integration-testing, e2e-testing, msw-mocking, vcr-http-recording, test-data-management, llm-testing |
+| **Architecture** | system-design-interrogation, brainstorming, context-engineering, resilience-patterns |
+| **DevOps** | devops-deployment, observability-monitoring, edge-computing-patterns, github-cli |
+| **LangGraph** | langgraph-state, langgraph-routing, langgraph-checkpoints, langgraph-human-in-loop, langgraph-supervisor, langgraph-parallel |
 
-### Agents (12)
+### Agents (20)
 
+**Product Thinking (6)**
+- `product-strategist` - Value proposition, business alignment
+- `requirements-translator` - PRDs, user stories, acceptance criteria
+- `prioritization-analyst` - RICE/ICE/WSJF scoring, backlog ranking
+- `ux-researcher` - Personas, user journeys, validation
+- `market-intelligence` - Competitive analysis, TAM/SAM/SOM
+- `business-case-builder` - ROI, cost-benefit analysis
+
+**Technical Implementation (14)**
 - `backend-system-architect` - API design, database schemas, microservices
 - `frontend-ui-developer` - React 19, TypeScript, accessibility
 - `database-engineer` - PostgreSQL, pgvector, migrations
@@ -42,9 +51,11 @@ git clone https://github.com/yonatangross/skillforge-claude-plugin .claude
 - `debug-investigator` - Root cause analysis
 - `data-pipeline-engineer` - Embeddings, ETL, vector indexing
 - `rapid-ui-designer` - UI/UX, wireframing, prototyping
-- `ux-researcher` - User research, personas, journey mapping
+- `metrics-architect` - OKRs, KPIs, instrumentation
+- `security-layer-auditor` - Defense-in-depth verification
+- `system-design-reviewer` - Architecture review
 
-### Commands (10)
+### Commands (12)
 
 | Command | Description |
 |---------|-------------|
@@ -58,21 +69,26 @@ git clone https://github.com/yonatangross/skillforge-claude-plugin .claude
 | `/run-tests` | Comprehensive test execution |
 | `/add-golden` | Add documents to golden dataset |
 | `/brainstorm` | Multi-perspective idea exploration |
+| `/configure` | Configure SkillForge bundles and settings |
+| `/status` | Show current configuration status |
 
-### Hooks (27)
+### Hooks (92)
 
 Security-hardened hooks for:
-- Lifecycle events (session start/end)
-- Pre-tool validation (file guards, git protection)
-- Post-tool auditing (metrics, error tracking)
-- Notifications (desktop, sound)
+- **Lifecycle**: Session start/end, context initialization
+- **Permission**: Auto-approval for safe operations
+- **Pre-tool**: File guards, git branch protection, bash validation
+- **Post-tool**: Audit logging, metrics, error tracking
+- **Notifications**: Desktop and sound alerts
+- **Stop**: Quality gates, subagent validation
 
 ## Key Features
 
-- **Progressive Loading**: Token-efficient skill loading via capabilities.json
-- **LangGraph 1.0**: Multi-agent workflows with checkpointing
-- **Security-First**: OWASP Top 10, defense-in-depth, LLM safety
+- **Progressive Loading**: Token-efficient skill loading via capabilities.json (Tier 1-4)
+- **LangGraph 1.0**: Multi-agent workflows with checkpointing and human-in-the-loop
+- **Security-First**: OWASP Top 10, defense-in-depth, LLM safety patterns
 - **Production-Ready**: Patterns for FastAPI, React 19, PostgreSQL/pgvector
+- **CC 2.1.2 Compliant**: All hooks tested and compliant
 
 ## Repository
 


### PR DESCRIPTION
## Summary

Adding **SkillForge** - The Complete AI Development Toolkit for Claude Code.

## Plugin Overview

| Component | Count | Description |
|-----------|-------|-------------|
| Skills | 78 | AI/LLM, backend, frontend, security, testing, architecture |
| Agents | 20 | 6 product thinking + 14 technical implementation agents |
| Commands | 12 | /implement, /explore, /verify, /commit, /configure, etc. |
| Hooks | 90 | Security-hardened lifecycle, permission, and tool hooks |
| Bundles | 4 | Tiered bundles: complete, standard, lite, hooks-only |

## Installation

```bash
# Full toolkit (default)
/plugin install @skillforge

# Or specific tiers:
/plugin install @skillforge/complete      # Everything (78 skills, 20 agents)
/plugin install @skillforge/standard      # All skills, no agents
/plugin install @skillforge/lite          # 10 essential skills
/plugin install @skillforge/hooks-only    # Just safety hooks
```

## Key Features

- **Progressive Loading**: Skills load on-demand based on task context
- **Safety Hooks**: Branch protection, file guards, secret redaction (always on)
- **Multi-Agent Workflows**: Product thinking + technical implementation agents
- **CC 2.1.2 Compliant**: All hooks tested and compliant

## Testing

- 39/39 config system tests pass
- 35/35 CC 2.1.2 compliance tests pass
- Comprehensive test suite in `tests/`

## Repository

https://github.com/yonatangross/skillforge-claude-plugin