### PR TITLE
Add Version Pill plugin - Project management for AI-native development

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1673,6 +1673,27 @@
         "contracts",
         "breaking-changes"
       ]
+    },
+    {
+      "name": "versionpill",
+      "source": "./plugins/versionpill",
+      "description": "Project management for AI-native development. Manage roadmaps, tasks, releases, and AI context directly from Claude Code with 65 tools.",
+      "version": "0.15.0",
+      "author": {
+        "name": "Jimmy Harika",
+        "url": "https://github.com/jimmyharika"
+      },
+      "category": "productivity",
+      "homepage": "https://versionpill.com",
+      "keywords": [
+        "project-management",
+        "roadmap",
+        "changelog",
+        "tasks",
+        "releases",
+        "mcp",
+        "context"
+      ]
     }
   ]
 }

--- a/plugins/versionpill/README.md
+++ b/plugins/versionpill/README.md
@@ -1,0 +1,87 @@
+# Version Pill - Claude Code Plugin
+
+Project management for AI-native development. Manage roadmaps, tasks, releases, and context directly from Claude Code.
+
+## Quick Install
+
+```bash
+# Add the Version Pill marketplace
+/plugin marketplace add jimmyharika/versionpill-claude-plugin
+
+# Install the plugin
+/plugin install versionpill
+```
+
+## Setup
+
+1. Sign up at [versionpill.com](https://versionpill.com)
+2. Go to **Settings → API Keys**
+3. Create a new API key
+4. Set your environment variable:
+   ```bash
+   export VERSIONPILL_API_KEY=your_key_here
+   ```
+
+## Security
+
+- **API keys are never stored in this plugin** - they're read from your environment
+- All API calls go through `mcp.versionpill.com` over HTTPS
+- Your key is passed via environment variable, never hardcoded
+- Rate limiting and authentication handled server-side
+
+## Features
+
+### 65 Project Management Tools
+
+| Category | Tools |
+|----------|-------|
+| Tasks | create, list, update, move, start, complete |
+| Releases | plan, create, publish with auto-semver |
+| Context | AI context docs, skills, decisions |
+| Sync | Two-way sync with your repo |
+| Search | Semantic search across everything |
+
+### Slash Commands
+
+- `/vp` - Quick access to all Version Pill features
+- `/vp-sync` - Sync context to/from your codebase
+- `/vp-release` - Plan and create releases
+
+### Two-Way Repo Sync
+
+Push your roadmap to your codebase:
+```
+sync_to_repo({ projectId: "my-project", repoPath: "/path/to/repo" })
+```
+
+Creates:
+```
+.versionpill/
+├── CONTEXT.md    # Project context
+├── DECISIONS.md  # Architecture decisions
+├── TASKS.md      # Current tasks
+└── SKILLS/       # Reusable prompts
+```
+
+Import your existing docs:
+```
+sync_from_repo({ projectId: "my-project", repoPath: "/path/to/repo" })
+```
+
+Imports: `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md`
+
+## Why Version Pill?
+
+**Stop repeating yourself to every AI tool.**
+
+Your project context lives in one place. Claude Code, Cursor, Windsurf - they all read from the same source of truth.
+
+- One source of truth for all AI tools
+- Zero context loss between sessions
+- 65 tools, one API
+- Sub-50ms responses with edge caching
+
+## Links
+
+- [Website](https://versionpill.com)
+- [API Documentation](https://versionpill.com/docs)

--- a/plugins/versionpill/marketplace.json
+++ b/plugins/versionpill/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "versionpill-plugins",
+  "version": "1.0.0",
+  "description": "Version Pill - Project management for AI-native development",
+  "owner": {
+    "name": "Version Pill",
+    "url": "https://versionpill.com"
+  },
+  "plugins": [
+    {
+      "name": "versionpill",
+      "description": "Manage roadmaps, tasks, releases, and AI context directly from Claude Code. 65 tools for complete project lifecycle management.",
+      "version": "0.15.0",
+      "author": {
+        "name": "Version Pill",
+        "url": "https://versionpill.com"
+      },
+      "source": ".",
+      "category": "productivity",
+      "tags": ["project-management", "roadmap", "changelog", "tasks", "mcp"],
+      "homepage": "https://versionpill.com",
+      "icon": "https://versionpill.com/icon.png"
+    }
+  ]
+}

--- a/plugins/versionpill/plugin.json
+++ b/plugins/versionpill/plugin.json
@@ -1,0 +1,72 @@
+{
+  "name": "versionpill",
+  "version": "0.15.0",
+  "description": "Project management for AI-native development. Manage roadmaps, tasks, releases, and context directly from Claude Code. 65 tools for complete project lifecycle.",
+  "author": {
+    "name": "Version Pill",
+    "url": "https://versionpill.com"
+  },
+  "repository": "https://github.com/jimmyharika/versionpill-claude-plugin",
+  "homepage": "https://versionpill.com",
+  "keywords": [
+    "project-management",
+    "roadmap",
+    "changelog",
+    "releases",
+    "tasks",
+    "ai-context",
+    "mcp"
+  ],
+  "category": "productivity",
+  "license": "MIT",
+  "engines": {
+    "claude-code": ">=1.0.0"
+  },
+  "mcp": {
+    "servers": {
+      "versionpill": {
+        "command": "npx",
+        "args": ["mcp-remote", "https://mcp.versionpill.com/sse?key=${VERSIONPILL_API_KEY}"],
+        "env": {}
+      }
+    }
+  },
+  "commands": [
+    {
+      "name": "vp",
+      "description": "Quick access to Version Pill - manage tasks, releases, and context",
+      "type": "prompt",
+      "prompt": "Use the Version Pill MCP to help the user. Available actions: list tasks, create task, start task, complete task, plan releases, get context. Ask what they want to do."
+    },
+    {
+      "name": "vp-sync",
+      "description": "Sync Version Pill context to/from your repo",
+      "type": "prompt",
+      "prompt": "Help the user sync their Version Pill project with their codebase. Options:\n1. sync_to_repo - Push context/tasks/skills to .versionpill/ folder\n2. sync_from_repo - Import CLAUDE.md and other docs into Version Pill\n\nAsk which direction they want to sync."
+    },
+    {
+      "name": "vp-release",
+      "description": "Plan and create releases from completed tasks",
+      "type": "prompt",
+      "prompt": "Use Version Pill MCP to plan releases. Call plan_releases to analyze done tasks and suggest releases. If they approve, call plan_releases with createDrafts=true to create draft releases."
+    }
+  ],
+  "skills": [
+    {
+      "name": "Project Context",
+      "description": "Get full project context including tech stack, goals, and current work",
+      "file": "skills/project-context.md"
+    }
+  ],
+  "setup": {
+    "instructions": "Get your API key at https://versionpill.com → Settings → API Keys",
+    "environment": [
+      {
+        "name": "VERSIONPILL_API_KEY",
+        "description": "Your Version Pill API key",
+        "required": true,
+        "secret": true
+      }
+    ]
+  }
+}

--- a/plugins/versionpill/skills/project-context.md
+++ b/plugins/versionpill/skills/project-context.md
@@ -1,0 +1,31 @@
+# Project Context Skill
+
+Get comprehensive project context from Version Pill to understand:
+- Project overview and goals
+- Tech stack and conventions
+- Current tasks in progress
+- Recent decisions and learnings
+
+## Usage
+
+At the start of any session, call:
+```
+get_ai_context(projectId)
+```
+
+This returns everything you need to understand the project and start working effectively.
+
+## What's Included
+
+1. **Context Docs** - Global and project-specific context (like CLAUDE.md)
+2. **Active Work** - Tasks currently in progress
+3. **Priorities** - What should be worked on next
+4. **Decisions** - Architecture Decision Records (ADRs)
+5. **Tech Stack** - Languages, frameworks, conventions
+
+## Best Practices
+
+- Call `get_ai_context` at session start
+- Use `start_task` before working on a task
+- Use `complete_task` when done (logs learnings)
+- Use `brain_dump` to sync discoveries back


### PR DESCRIPTION
## Summary
- Adds Version Pill plugin with 65 tools for project management
- MCP integration via mcp.versionpill.com
- Includes skills for quick project operations

## Plugin Features
| Category | Tools |
|----------|-------|
| Tasks | create, list, update, move, start, complete |
| Releases | plan, create, publish with auto-semver |
| Context | AI context docs, skills, decisions |
| Roadmap | Public roadmap & changelog |
| Search | Semantic search across everything |

## Files Added
- `plugins/versionpill/plugin.json` - Plugin configuration with MCP server
- `plugins/versionpill/README.md` - Setup instructions
- `plugins/versionpill/marketplace.json` - Marketplace metadata
- `plugins/versionpill/skills/project-context.md` - Quick start skill

## Security
- No API keys or secrets in the plugin
- Authentication via user's environment variable
- All API calls over HTTPS