### PR TITLE
Add gr0m_mem — persistent memory brain plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1721,7 +1721,7 @@
       ]
     },
     {
-      "name": "gr0m_mem",
+      "name": "gr0m-mem",
       "source": "./plugins/gr0m-mem",
       "description": "Persistent memory brain that stops Claude from re-asking and re-deriving across sessions. SQLite FTS5 zero-install default, ChromaDB + Ollama on the semantic branch.",
       "version": "0.1.0",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1719,6 +1719,27 @@
         "productivity",
         "templates"
       ]
+    },
+    {
+      "name": "gr0m_mem",
+      "source": "./plugins/gr0m-mem",
+      "description": "Persistent memory brain that stops Claude from re-asking and re-deriving across sessions. SQLite FTS5 zero-install default, ChromaDB + Ollama on the semantic branch.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Michael Adam Groberman",
+        "url": "https://github.com/MichaelAdamGroberman"
+      },
+      "category": "productivity",
+      "homepage": "https://github.com/MichaelAdamGroberman/gr0m_mem",
+      "license": "MIT",
+      "keywords": [
+        "memory",
+        "rag",
+        "sqlite",
+        "mcp",
+        "loop-prevention",
+        "temporal-knowledge-graph"
+      ]
     }
   ]
 }

--- a/plugins/gr0m-mem/.claude-plugin/plugin.json
+++ b/plugins/gr0m-mem/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "gr0m_mem",
+  "name": "gr0m-mem",
   "description": "Persistent memory brain that stops Claude from re-asking and re-deriving across sessions. SQLite FTS5 zero-install default, ChromaDB + Ollama semantic retrieval on the semantic branch. Temporal knowledge graph, per-corpus isolation, loop-prevention protocol, and session hooks.",
   "version": "0.1.0",
   "author": {
@@ -18,10 +18,5 @@
     "temporal-knowledge-graph",
     "mcp"
   ],
-  "mcpServers": {
-    "gr0m_mem": {
-      "command": "python",
-      "args": ["-m", "gr0m_mem.mcp_server"]
-    }
-  }
+  "mcpServers": "./.mcp.json"
 }

--- a/plugins/gr0m-mem/.claude-plugin/plugin.json
+++ b/plugins/gr0m-mem/.claude-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "gr0m_mem",
+  "description": "Persistent memory brain that stops Claude from re-asking and re-deriving across sessions. SQLite FTS5 zero-install default, ChromaDB + Ollama semantic retrieval on the semantic branch. Temporal knowledge graph, per-corpus isolation, loop-prevention protocol, and session hooks.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Michael Adam Groberman",
+    "url": "https://github.com/MichaelAdamGroberman"
+  },
+  "homepage": "https://github.com/MichaelAdamGroberman/gr0m_mem",
+  "license": "MIT",
+  "keywords": [
+    "memory",
+    "rag",
+    "sqlite",
+    "chromadb",
+    "wakeup",
+    "loop-prevention",
+    "temporal-knowledge-graph",
+    "mcp"
+  ],
+  "mcpServers": {
+    "gr0m_mem": {
+      "command": "python",
+      "args": ["-m", "gr0m_mem.mcp_server"]
+    }
+  }
+}

--- a/plugins/gr0m-mem/.mcp.json
+++ b/plugins/gr0m-mem/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "gr0m_mem": {
+      "command": "python",
+      "args": ["-m", "gr0m_mem.mcp_server"]
+    }
+  }
+}


### PR DESCRIPTION
## Plugin: gr0m_mem

**Repo**: https://github.com/MichaelAdamGroberman/gr0m_mem
**PyPI**: https://pypi.org/project/gr0m-mem/
**License**: MIT

### What it does

Zero-install persistent memory brain for Claude Code that stops the model from re-asking and re-deriving across sessions. Four MCP tools (`mem_wakeup`, `mem_record_decision`, `mem_recall_decisions`, `mem_remember`) plus Stop and PreCompact hooks.

### Features

- **SQLite FTS5** default backend — `pip install gr0m-mem` and it works, no extras
- **ChromaDB + Ollama** semantic retrieval on the `semantic` branch
- **Temporal knowledge graph** with mandatory `as_of` filtering
- **Per-corpus isolation** — documents from different projects never mix
- **Loop-prevention protocol** — benchmarked at 100% in CI
- **Session hooks** — auto-flush milestones on Stop and PreCompact

### Install

```bash
pip install gr0m-mem
```

### Works with

Claude Code, Claude Desktop, Cursor, Gemini CLI, Continue, Cline, Zed, OpenAI Codex CLI, Aider, and any MCP client.